### PR TITLE
Interval Flash: Fix incorrect default counterMaxLength

### DIFF
--- a/app/src/main/res/layout/dialog_interval.xml
+++ b/app/src/main/res/layout/dialog_interval.xml
@@ -69,7 +69,7 @@
         android:paddingStart="24dp"
         android:paddingTop="6dp"
         app:counterEnabled="true"
-        app:counterMaxLength="4"
+        app:counterMaxLength="5"
         app:suffixText="ms">
 
         <com.google.android.material.textfield.TextInputEditText


### PR DESCRIPTION
Ideally it shouldn't be defined separately here and in `switchToTime()` but at least this brings them in harmony with one another.

|Old behaviour|Intended new|
|---|---|
|![Screenshot_20240121_001331_FlashDim](https://github.com/cyb3rko/flashdim/assets/60154347/177472c9-a1fc-4dcb-9da4-5f15521807da)|![Screenshot_20240121_001640_FlashDim](https://github.com/cyb3rko/flashdim/assets/60154347/43ac51a4-5b71-4dc4-beb4-7ea688a1478d)|