### PR TITLE
 feat(QsTile/Dimmer): continue cycle from current strength level 

### DIFF
--- a/app/src/main/kotlin/com/cyb3rko/flashdim/tiles/DimmerSettingsTile.kt
+++ b/app/src/main/kotlin/com/cyb3rko/flashdim/tiles/DimmerSettingsTile.kt
@@ -74,7 +74,9 @@ class DimmerSettingsTile : TileService() {
                 object : CameraManager.TorchCallback() {
                     override fun onTorchModeChanged(cameraId: String, enabled: Boolean) {
                         if (qsTile == null) return
-                        if (description.isNotEmpty()) qsTile.subtitle = "State: $description"
+                        qsTile.subtitle =
+                            if (description.isNotEmpty() && enabled) "State: $description"
+                            else "State: ${DIMMER_OFF.description()}"
                         qsTile.state = if (enabled) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
                         qsTile.updateTile()
                         this@DimmerSettingsTile.enabled = enabled

--- a/app/src/main/kotlin/com/cyb3rko/flashdim/tiles/DimmerSettingsTile.kt
+++ b/app/src/main/kotlin/com/cyb3rko/flashdim/tiles/DimmerSettingsTile.kt
@@ -28,11 +28,15 @@ import com.cyb3rko.flashdim.utils.Safe
 
 class DimmerSettingsTile : TileService() {
     private var description = ""
+    private var enabled = false
 
     override fun onClick() {
         if (qsTile.state == Tile.STATE_UNAVAILABLE) return
         Safe.initialize(applicationContext)
-        val mode = Safe.getInt(Safe.QUICKTILE_DIM_MODE, DIMMER_MIN)
+        var mode = Safe.getInt(Safe.QUICKTILE_DIM_MODE, DIMMER_MIN)
+        if (!enabled)
+            // torch was disabled externally, continue again from initial state
+            mode = DIMMER_MIN
         description = mode.description()
 
         val maxLevel = Safe.getInt(Safe.MAX_LEVEL, -1)
@@ -73,6 +77,7 @@ class DimmerSettingsTile : TileService() {
                         if (description.isNotEmpty()) qsTile.subtitle = "State: $description"
                         qsTile.state = if (enabled) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
                         qsTile.updateTile()
+                        this@DimmerSettingsTile.enabled = enabled
                     }
                 },
                 Handler(Looper.getMainLooper())

--- a/app/src/main/kotlin/com/cyb3rko/flashdim/utils/Safe.kt
+++ b/app/src/main/kotlin/com/cyb3rko/flashdim/utils/Safe.kt
@@ -31,7 +31,6 @@ internal object Safe {
     const val MORSE_VIBRATION = "morse_vibration"
     const val MULTILEVEL = "multilevel"
     const val PAUSE_FLASH = "pause_flash"
-    const val QUICKTILE_DIM_MODE = "dim_mode"
     const val QUICK_SETTINGS_LINK = "quick_settings_link"
     const val REPORT_DIALOG_SHOWN = "${BuildConfig.VERSION_CODE}-report_dialog"
     const val STARTUP_COUNTER = "startup_counter"


### PR DESCRIPTION
Continues the cycle from the current strength level by mapping the current level to the next cycle level. For example, if the user has already activated the torch from another application and has set it to 2 (out of 10), the tile will show the minimum state.

Built on/replaces https://github.com/cyb3rko/flashdim/pull/78