### PR TITLE
Fix volume shortcut with stale preferred flashlight levels

### DIFF
--- a/app/src/main/kotlin/com/cyb3rko/flashdim/Camera.kt
+++ b/app/src/main/kotlin/com/cyb3rko/flashdim/Camera.kt
@@ -75,16 +75,30 @@ internal class Camera(activity: AppCompatActivity) {
         fun doesDeviceHaveFlash(packageManager: PackageManager): Boolean =
             packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)
 
+        fun getValidFlashLevel(
+            cameraManager: CameraManager,
+            cameraId: String,
+            requestedLevel: Int
+        ): Int {
+            if (requestedLevel < 1) return -1
+
+            val maxLevel = cameraManager.getCameraCharacteristics(cameraId)
+                .get(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL)
+                ?: return -1
+            return requestedLevel.coerceAtMost(maxLevel)
+        }
+
         fun sendLightLevel(context: Context, level: Int, activate: Boolean) {
             try {
                 val cameraManager = context.getSystemService(Context.CAMERA_SERVICE)
                     as CameraManager
                 val cameraId = cameraManager.cameraIdList[0]
                 if (activate) {
-                    if (level == -1) {
+                    val validLevel = getValidFlashLevel(cameraManager, cameraId, level)
+                    if (validLevel == -1) {
                         cameraManager.setTorchMode(cameraId, true)
                     } else {
-                        cameraManager.turnOnTorchWithStrengthLevel(cameraId, level)
+                        cameraManager.turnOnTorchWithStrengthLevel(cameraId, validLevel)
                     }
                 } else {
                     cameraManager.setTorchMode(cameraId, false)

--- a/app/src/main/kotlin/com/cyb3rko/flashdim/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/cyb3rko/flashdim/activities/MainActivity.kt
@@ -96,7 +96,8 @@ class MainActivity : AppCompatActivity() {
         maxLevel = camera.maxLevel
         Safe.initialize(this)
         Safe.writeInt(Safe.MAX_LEVEL, maxLevel)
-        if (Safe.getInt(Safe.PREFERRED_LEVEL, -1) == -1) {
+        val preferredLevel = Safe.getInt(Safe.PREFERRED_LEVEL, -1)
+        if (maxLevel > 0 && preferredLevel !in 1..maxLevel) {
             Safe.writeInt(Safe.PREFERRED_LEVEL, maxLevel)
         }
 

--- a/app/src/main/kotlin/com/cyb3rko/flashdim/quicksettings/SettingsTile.kt
+++ b/app/src/main/kotlin/com/cyb3rko/flashdim/quicksettings/SettingsTile.kt
@@ -23,6 +23,7 @@ import android.os.Looper
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import android.util.Log
+import com.cyb3rko.flashdim.Camera
 import com.cyb3rko.flashdim.handleFlashlightException
 import com.cyb3rko.flashdim.utils.Safe
 
@@ -192,14 +193,16 @@ class SettingsTile : TileService() {
     }
 
     private fun sendFlashlightSignal(cameraManager: CameraManager, level: Int, activate: Boolean) {
+        val cameraId = cameraManager.cameraIdList[0]
         if (activate) {
-            if (level == -1) {
-                cameraManager.setTorchMode(cameraManager.cameraIdList[0], true)
+            val validLevel = Camera.getValidFlashLevel(cameraManager, cameraId, level)
+            if (validLevel == -1) {
+                cameraManager.setTorchMode(cameraId, true)
             } else {
-                cameraManager.turnOnTorchWithStrengthLevel(cameraManager.cameraIdList[0], level)
+                cameraManager.turnOnTorchWithStrengthLevel(cameraId, validLevel)
             }
         } else {
-            cameraManager.setTorchMode(cameraManager.cameraIdList[0], false)
+            cameraManager.setTorchMode(cameraId, false)
         }
     }
 

--- a/app/src/main/kotlin/com/cyb3rko/flashdim/service/VolumeButtonService.kt
+++ b/app/src/main/kotlin/com/cyb3rko/flashdim/service/VolumeButtonService.kt
@@ -70,15 +70,10 @@ class VolumeButtonService : AccessibilityService() {
         return false
     }
 
-    private fun getFlashLevel(): Int {
-        if (!Safe.getBoolean(Safe.VOLUME_BUTTONS_LINK, false)) return -1
-
-        val preferredLevel = Safe.getInt(Safe.PREFERRED_LEVEL, -1)
-        if (preferredLevel < 1) return -1
-
-        val cameraManager = getSystemService(Context.CAMERA_SERVICE) as CameraManager
-        val cameraId = cameraManager.cameraIdList.firstOrNull() ?: return -1
-        return Camera.getValidFlashLevel(cameraManager, cameraId, preferredLevel)
+    private fun getFlashLevel(): Int = if (Safe.getBoolean(Safe.VOLUME_BUTTONS_LINK, false)) {
+        Safe.getInt(Safe.PREFERRED_LEVEL, -1)
+    } else {
+        -1
     }
 
     override fun onInterrupt() {

--- a/app/src/main/kotlin/com/cyb3rko/flashdim/service/VolumeButtonService.kt
+++ b/app/src/main/kotlin/com/cyb3rko/flashdim/service/VolumeButtonService.kt
@@ -70,10 +70,15 @@ class VolumeButtonService : AccessibilityService() {
         return false
     }
 
-    private fun getFlashLevel(): Int = if (Safe.getBoolean(Safe.VOLUME_BUTTONS_LINK, false)) {
-        Safe.getInt(Safe.PREFERRED_LEVEL, -1)
-    } else {
-        -1
+    private fun getFlashLevel(): Int {
+        if (!Safe.getBoolean(Safe.VOLUME_BUTTONS_LINK, false)) return -1
+
+        val preferredLevel = Safe.getInt(Safe.PREFERRED_LEVEL, -1)
+        if (preferredLevel < 1) return -1
+
+        val cameraManager = getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        val cameraId = cameraManager.cameraIdList.firstOrNull() ?: return -1
+        return Camera.getValidFlashLevel(cameraManager, cameraId, preferredLevel)
     }
 
     override fun onInterrupt() {


### PR DESCRIPTION
## Problem

FlashDim can keep a preferred flashlight level that the current device no longer supports. This can happen in two common ways:

- An Android update lowers the number of flashlight strength levels, such as a Pixel changing from 45 supported levels to 21 while FlashDim still has 45 selected.
- Android restores FlashDim's settings onto a new phone whose flashlight has a lower maximum than the previous phone.

This creates a particularly confusing failure in the volume-button shortcut:

- The FlashDim app can still turn the flashlight on and off.
- Pressing both volume buttons while the flashlight is off does not turn it on.
- Pressing both volume buttons while the flashlight is on still turns it off.

The shortcut's on-path passes the stale preferred level to `turnOnTorchWithStrengthLevel()`, which rejects a level above the device's current maximum. The off-path does not pass a strength level, so it continues to work.

## What changed

- Clamp a requested preferred level to the camera's current Camera2 maximum before turning the flashlight on.
- Apply the same validation to the volume-button service and the linked Quick Settings tile.
- Normalize the saved preferred level when the app discovers that the device's maximum has changed.
- Fall back to regular torch mode when strength levels are unavailable.

This preserves the user's linked-level setting while preventing an old or restored value from breaking flashlight activation.

## Related issue

Addresses the stale `45` versus new `21` level failure reported in #146.

## Validation

Tested with the upstream app on an Android 17 / API 37 Pixel 10 Pro XL emulator profile using simultaneous kernel-level volume-up and volume-down events.

Baseline reproduction with preferred level `45` and current maximum `10`:

1. App controls turned the flashlight on and off normally.
2. With the flashlight off, the service logged `Both volume buttons pressed`, but the flashlight stayed off.
3. With the flashlight on, the same volume-button chord turned it off.

Patched behavior with the same stale `45` preference:

1. The volume-button chord turned the flashlight on at the valid maximum level `10`.
2. The next identical chord turned it off.
3. Opening the app normalized the saved preferred level from `45` to `10`.
4. `:app:assembleDebug` completed successfully.
